### PR TITLE
Add preliminary support for native macOS

### DIFF
--- a/DevicePpi.xcodeproj/project.pbxproj
+++ b/DevicePpi.xcodeproj/project.pbxproj
@@ -399,6 +399,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.clafou.DevicePpi;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -426,6 +428,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.clafou.DevicePpi;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Tests/DevicePpiTests/DevicePpiTests.swift
+++ b/Tests/DevicePpiTests/DevicePpiTests.swift
@@ -23,6 +23,7 @@ class DevicePpiTests: XCTestCase {
         XCTAssertThrowsError(try Ppi.lookUp(machineName: "DoesNotExist"))
     }
     
+    #if canImport(UIKit)
     func testUnknownRetinaIPad() {
         let ppi = Ppi.guess(idiom: .pad, screen: MockScreen(scale: 2, nativeScale: 2))
         XCTAssertEqual(ppi, 264)
@@ -42,8 +43,16 @@ class DevicePpiTests: XCTestCase {
         let ppi = Ppi.guess(idiom: .pad, screen: MockScreen(scale: 1, nativeScale: 1))
         XCTAssertEqual(ppi, 132)
     }
+    #endif
+    
+    #if canImport(AppKit)
+    func testMac() {
+        XCTAssertNotEqual(Ppi.screenPpi(screen: NSScreen.main), 72)
+    }
+    #endif
 }
 
+#if canImport(UIKit)
 class MockScreen: UIScreen {
     
     let _scale: CGFloat
@@ -67,3 +76,4 @@ class MockScreen: UIScreen {
         }
     }
 }
+#endif


### PR DESCRIPTION
Hi,

After adding your wonderful library to a project that needs to display a view to a specific sizes in millimeters, i have later noticed the library doesnt currently support macOS. I have added some initial support.

Note that the DPI that can be computed using CGDisplayCopyDisplayMode is not the physical DPI of the device, rather it is the logical DPI of the currently chosen mode. For instance if i select the "More space" option on my M1 MacBook Pro 14", it reports 303 DPI, because it emulates a display of 3600x2338 pixels, that is uses as a 1800x1169 @2x display.

I haven't found a way to get the physical DPI except for going over all models as you did and hardcoding them. 

I actually am not sure this would be preferable, since this library might be used like in my case to render a view at a specific width in physical units, in which case the logical DPI is the one we need to achieve that.

If you have any specific questions about the pull request or would like any changes, do ask, i would love to be able to contribute this code if you're open to it, in a way it integrates properly into the existing code.